### PR TITLE
fix: Syntax errors from ICCC replacement - broken variable names

### DIFF
--- a/src/components/SEO/CapabilitiesSchema.jsx
+++ b/src/components/SEO/CapabilitiesSchema.jsx
@@ -46,7 +46,7 @@ const EMS_PLATFORM_SCHEMA = {
 };
 
 // ── VMukti Enterprise Command Center Schema ──
-const Enterprise Command Center_PLATFORM_SCHEMA = {
+const ECC_PLATFORM_SCHEMA = {
   '@context': 'https://schema.org',
   '@type': 'SoftwareApplication',
   name: 'VMukti Enterprise Command Center - Integrated Command & Control Center',
@@ -161,7 +161,7 @@ const CapabilitiesSchema = ({ includeVMS = true, includeEMS = true, includeEnter
       )}
       {includeEnterprise Command Center && (
         <Helmet>
-          <script type="application/ld+json">{JSON.stringify(Enterprise Command Center_PLATFORM_SCHEMA)}</script>
+          <script type="application/ld+json">{JSON.stringify(ECC_PLATFORM_SCHEMA)}</script>
         </Helmet>
       )}
       {includeCloudAI && (

--- a/src/data/schemaData.js
+++ b/src/data/schemaData.js
@@ -587,7 +587,7 @@ export const emsSchema = {
   },
 };
 
-export const enterprise-command-centerSchema = {
+export const enterpriseCommandCenterSchema = {
   '@context': 'https://schema.org',
   '@type': 'SoftwareApplication',
   name: 'VMukti Enterprise Command Center (Integrated Command and Control Center)',
@@ -662,7 +662,7 @@ const schemaData = {
     productpageSchema,
     cloudVmsSchema,
     emsSchema,
-    enterprise-command-centerSchema,
+    enterpriseCommandCenterSchema,
     organizationSchema,
   ],
 };


### PR DESCRIPTION
- CapabilitiesSchema.jsx: "const Enterprise Command Center_PLATFORM_SCHEMA" → "const ECC_PLATFORM_SCHEMA"
- schemaData.js: "export const enterprise-command-centerSchema" → "export const enterpriseCommandCenterSchema"
- Fixed all references to these variables

These were caused by the bulk ICCC→Enterprise Command Center replacement which broke JavaScript variable naming rules (no spaces/hyphens in identifiers).