### PR TITLE
SEO: Add 301 redirects to fix 40+ Soft 404 pages from GSC

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -38,12 +38,52 @@ const nextConfig = {
 
   async redirects() {
     return [
+      // Domain redirect: vmukti.com → www.vmukti.com
       {
         source: "/:path*",
         has: [{ type: "host", value: "vmukti.com" }],
         destination: "https://www.vmukti.com/:path*",
         permanent: true,
       },
+      // Legacy page redirects (fixing 101 Soft 404s in GSC)
+      { source: "/about", destination: "/about-us", permanent: true },
+      { source: "/contact", destination: "/contact-us", permanent: true },
+      { source: "/privacy", destination: "/privacy-policy", permanent: true },
+      { source: "/book-demo", destination: "/book-a-demo", permanent: true },
+      { source: "/career", destination: "/careers", permanent: true },
+      { source: "/career/", destination: "/careers", permanent: true },
+      { source: "/about-vmukti", destination: "/about-us", permanent: true },
+      { source: "/about-vmukti/", destination: "/about-us", permanent: true },
+      { source: "/industries", destination: "/industry", permanent: true },
+      // Old product URLs → new solution pages
+      { source: "/products/vms", destination: "/products/vms-vas/", permanent: true },
+      { source: "/products/edge-ai-camera", destination: "/solution/edge-ai", permanent: true },
+      { source: "/products/edge-ai-camera/", destination: "/solution/edge-ai", permanent: true },
+      { source: "/products/smart-city-camera", destination: "/industry/smart-city", permanent: true },
+      { source: "/products/smart-city-camera/", destination: "/industry/smart-city", permanent: true },
+      { source: "/products/face-recognation-camera", destination: "/solution/face-recognition", permanent: true },
+      { source: "/products/face-recognation-camera/", destination: "/solution/face-recognition", permanent: true },
+      { source: "/products/anpr-camera", destination: "/solution/anpr-lpr", permanent: true },
+      { source: "/products/anpr-camera/", destination: "/solution/anpr-lpr", permanent: true },
+      { source: "/products/ambicam-4g-camera", destination: "/Ambicam", permanent: true },
+      { source: "/products/ambicam-4g-camera/", destination: "/Ambicam", permanent: true },
+      { source: "/products/object-detection-camera", destination: "/solution/ai-video-analytics", permanent: true },
+      { source: "/products/object-detection-camera/", destination: "/solution/ai-video-analytics", permanent: true },
+      // Old regional URLs
+      { source: "/video-surveillance-solutions-usa", destination: "/usa/video-surveillance-solutions", permanent: true },
+      { source: "/video-surveillance-solutions-uk", destination: "/uk/video-surveillance-solutions", permanent: true },
+      // Old blog slugs → new blog URLs
+      { source: "/cloud-based-video-security-solution", destination: "/blog/cloud-based-video-surveillance-benefits", permanent: true },
+      { source: "/cloud-based-video-security-solution/", destination: "/blog/cloud-based-video-surveillance-benefits", permanent: true },
+      { source: "/best-live-streaming-services-provider-in-india/", destination: "/blog/best-live-streaming-services-provider-in-india", permanent: true },
+      { source: "/10-great-advantages-of-remote-security-and-video-surveillance/", destination: "/blog/advantages-of-remote-security-and-video-surveillance", permanent: true },
+      { source: "/artificial-intelligence-edge-ai-camera-solutions-with-video-monitoring-technology/", destination: "/solution/edge-ai", permanent: true },
+      { source: "/7-benefits-of-ai-powered-cctv-cameras-for-business-surveillance/", destination: "/solution/ai-video-analytics", permanent: true },
+      { source: "/the-latest-technology-of-cctv-surveillance-systems/", destination: "/blog/latest-technology-of-cctv-surveillance-systems", permanent: true },
+      { source: "/best-streaming-engine/", destination: "/blog/best-streaming-engine-for-webcast", permanent: true },
+      { source: "/exam-surveillance-solutions-ensuring-the-integrity-of-your-exams/", destination: "/industry/education", permanent: true },
+      // Industry contact-us subpages → main contact page
+      { source: "/industry/:name/contact-us", destination: "/contact-us", permanent: true },
     ];
   },
 


### PR DESCRIPTION
Added redirects in next.config.js for legacy URLs that Google reports as Soft 404:
- Old WordPress blog URLs → current blog pages
- Old product URLs (edge-ai-camera, anpr-camera, etc.) → current solution pages
- Legacy page variants (/about → /about-us, /contact → /contact-us, etc.)
- Old regional URLs → current regional pages
- Industry contact-us subpages → main contact page

101 pages reported as Soft 404 in GSC. This fixes ~40 of them with proper 301 redirects. Remaining soft 404s are from client-side rendering issues (need SSR fix separately).