### PR TITLE
fix: Homepage stats '0+' fallback + Industry page CTA routing

### DIFF
--- a/pages-src/Home/Components/Achieved.js
+++ b/pages-src/Home/Components/Achieved.js
@@ -88,7 +88,7 @@ const AnimatedValue = ({ value }) => {
 
   return (
     <span ref={ref}>
-      {count}
+      {count || numericValue}
       {suffix}
     </span>
   );

--- a/pages-src/IndustriesDashboard/industriesDashboard.js
+++ b/pages-src/IndustriesDashboard/industriesDashboard.js
@@ -786,7 +786,7 @@ export default function IndustryDashboard() {
           {/* Industry Grid */}
           {renderIndustryCards()}
         </Box>
-        <CtaBanner href="/contact-us">
+        <CtaBanner href="/book-a-demo">
           Modernize Your Industry's Future with Bold
           <br />
           Surveillance


### PR DESCRIPTION
1. Achieved.js: Stats counter now shows real number as fallback when count is 0 (before animation). Fixes "0+" display for Googlebot and slow connections. {count || numericValue} ensures 900+, 18+, etc. always visible.

2. industriesDashboard.js: CTA banner routed to /contact-us, changed to /book-a-demo to match user intent ("Book Demo" label).