### PR TITLE
fix: GSC structured data errors — duplicate FAQPage + invalid Product…

### DIFF
--- a/components/SEO/SEOIntegration.jsx
+++ b/components/SEO/SEOIntegration.jsx
@@ -33,8 +33,9 @@ const SEOIntegration = () => {
 
   return (
     <>
-      {/* FAQ Schema */}
-      <FAQSchema pageType={getPageType()} />
+      {/* FAQ Schema — REMOVED from global integration to prevent duplicate FAQPage errors.
+          Individual pages (industry, solution, blog) render their own FAQ schemas with
+          page-specific questions. Having both causes "Duplicate field FAQPage" in GSC. */}
 
       {/* Organization + LocalBusiness JSON-LD */}
       <LocalBusinessSchema region={getRegion()} />

--- a/components/SEO/SchemaMarkup.jsx
+++ b/components/SEO/SchemaMarkup.jsx
@@ -59,7 +59,7 @@ export const websiteSchema = {
 
 export const createProductSchema = (productData) => ({
   '@context': 'https://schema.org',
-  '@type': 'Product',
+  '@type': 'SoftwareApplication',
   name: productData.name,
   description: productData.description,
   image: productData.image,
@@ -104,7 +104,7 @@ export const createFAQSchema = (faqs) => ({
 export const vmuktiPlatforms = {
   cloudVMS: {
     '@context': 'https://schema.org',
-    '@type': 'Product',
+    '@type': 'SoftwareApplication',
     name: 'VMukti Cloud VMS',
     description: 'Enterprise-grade cloud-based Video Management System with STQC certification. Supports 1B+ concurrent camera feeds, AI-powered analytics, and enterprise campus integration. 900+ deployments across 700+ districts.',
     image: 'https://www.vmukti.com/products/cloud-vms.jpg',
@@ -123,7 +123,7 @@ export const vmuktiPlatforms = {
 
   ems: {
     '@context': 'https://schema.org',
-    '@type': 'Product',
+    '@type': 'SoftwareApplication',
     name: 'VMukti EMS (Enterprise Management System)',
     description: 'Comprehensive Enterprise Management System for coordinated surveillance operations, incident management, and cross-platform control. Seamlessly integrates with VMukti Cloud VMS and third-party systems.',
     image: 'https://www.vmukti.com/products/ems.jpg',
@@ -142,7 +142,7 @@ export const vmuktiPlatforms = {
 
   iccc: {
     '@context': 'https://schema.org',
-    '@type': 'Product',
+    '@type': 'SoftwareApplication',
     name: 'VMukti Enterprise Command Center',
     description: 'Integrated Command and Control Center platform for unified emergency response, enterprise campus operations, and cross-agency coordination. Features multi-agency dashboards, incident tracking, and real-time analytics.',
     image: 'https://www.vmukti.com/products/iccc.jpg',
@@ -161,7 +161,7 @@ export const vmuktiPlatforms = {
 
   genaiAnalytics: {
     '@context': 'https://schema.org',
-    '@type': 'Product',
+    '@type': 'SoftwareApplication',
     name: 'VMukti GenAI Video Analytics',
     description: 'Next-generation AI-powered video analytics engine for intelligent surveillance. Provides real-time object detection, behavioral analysis, crowd monitoring, and predictive insights. Processes 1B+ camera feeds globally.',
     image: 'https://www.vmukti.com/products/genai-analytics.jpg',


### PR DESCRIPTION
… snippets

1. SEOIntegration.jsx: Removed global FAQSchema from page wrapper. This was causing "Duplicate field FAQPage" on 80 pages because individual pages (industry, solution, blog) already render their own FAQ schemas with page-specific questions.

2. SchemaMarkup.jsx: Changed Product → SoftwareApplication for all VMukti platform schemas. Google requires a price field for Product type but VMukti uses "Contact for pricing" — SoftwareApplication doesn't require price and is more appropriate for SaaS.

Fixes: 80 invalid FAQ items + 17 invalid Product snippets in GSC.